### PR TITLE
add github ssh key to known_hosts

### DIFF
--- a/src/commands/install-cli.yml
+++ b/src/commands/install-cli.yml
@@ -62,6 +62,7 @@ steps:
         sonar-scanner --version \
           <<#parameters.output-file>>| tee <<parameters.output-file>><</parameters.output-file>>;
 
+        ssh-keyscan github.com >> ~/.ssh/known_hosts
       when: always
   - unless:
       condition: <<parameters.no-cache>>

--- a/src/commands/install-cli.yml
+++ b/src/commands/install-cli.yml
@@ -62,6 +62,7 @@ steps:
         sonar-scanner --version \
           <<#parameters.output-file>>| tee <<parameters.output-file>><</parameters.output-file>>;
 
+        mkdir ~/.ssh
         ssh-keyscan github.com >> ~/.ssh/known_hosts
       when: always
   - unless:


### PR DESCRIPTION
SonarCloud at one point tries to contact github to run blame, but isn't expecting the (new?) ssh key for github; the cli will sit stalled making no progress.

To remedy, add the github ssh key when installing the sonarcloud cli, so any invocations are ready to go.

```
INFO: js security sensor peak memory: 234 MB
INFO: Sensor JsSecuritySensor [security] (done) | time=1114ms
INFO: ------------- Run sensors on project
INFO: Sensor Zero Coverage Sensor
INFO: Sensor Zero Coverage Sensor (done) | time=16ms
INFO: SCM Publisher SCM provider for this project is: git
INFO: SCM Publisher 1 source file to be analyzed
The authenticity of host 'github.com (140.82.113.4)' can't be established.
ED25519 key fingerprint is SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? INFO: SCM blame is in progress..
INFO: SCM blame is in progress..
INFO: SCM blame is in progress..
INFO: SCM blame is in progress..
```